### PR TITLE
chore(LcForm): move options props

### DIFF
--- a/src/components/LcForm.vue
+++ b/src/components/LcForm.vue
@@ -26,6 +26,7 @@
         <lc-multiselect
           v-if="field.inputType === 'select' && !field.hidden"
           v-model="field.model"
+          :options="field.options"
           v-bind="field.attr"
         />
         <lc-textarea

--- a/src/stories/LcForm.stories.ts
+++ b/src/stories/LcForm.stories.ts
@@ -80,10 +80,10 @@ Base.args = {
     {
       model: null,
       inputType: 'select',
+      options: ['France', 'Indonésie', 'Espagne'],
       attr: {
         labelText: 'Pays',
         name: 'coutnry',
-        options: ['France', 'Indonésie', 'Espagne'],
         rules: 'required',
         wrapperClass: 'mb-4',
       },


### PR DESCRIPTION
Pour garder une uniformité entre nos composants, les options ne sont pas dans l'objet attr