### PR TITLE
chore(css): add form.css for initialize common form class

### DIFF
--- a/src/components/LcCheckbox/LcCheckbox.vue
+++ b/src/components/LcCheckbox/LcCheckbox.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <template v-if="multipleCheckbox">
-      <label v-for="checkbox in fields" :key="checkbox.label" class="label">
+      <label v-for="checkbox in fields" :key="checkbox.label" class="lc-checkbox-label ">
         <input
           v-model="inputValue"
           type="checkbox"
@@ -10,13 +10,13 @@
           :style="checkbox.value && checkbox.color ?
             { backgroundColor: checkbox.color , borderColor: checkbox.color } :
             { borderColor: checkbox.color }"
-          class="form-tick checkbox-custom"
+          class="lc-checkbox lc-form-tick"
           data-testid="lc-checkbox"
         >
         <span :style="checkbox.value && checkbox.color ? { color: checkbox.color } : ''">{{ checkbox.label }}</span>
       </label>
     </template>
-    <label v-else class="label">
+    <label v-else class="lc-checkbox-label ">
       <input
         v-model="inputValue"
         type="checkbox"
@@ -24,13 +24,13 @@
         :style="inputValue && color ? {
           backgroundColor: color, borderColor: color } :
           { borderColor: color }"
-        class="form-tick checkbox-custom"
+        class="lc-checkbox lc-form-tick"
         data-testid="lc-checkbox"
       >
       <span :style="inputValue && color ? { color: color } : ''">{{ label }}</span>
     </label>
 
-    <error-message as="div" :name="name" class="text-small text-red-300" />
+    <error-message as="div" :name="name" class="lc-form--error" />
   </div>
 </template>
 
@@ -97,18 +97,11 @@ export default defineComponent({
 })
 </script>
 
-<style scoped>
-.label {
+<style>
+.lc-checkbox-label {
   @apply cursor-pointer inline-flex justify-start items-center mr-4;
 }
-.checkbox-custom {
+.lc-checkbox {
   @apply appearance-none cursor-pointer mr-2 h-4 w-4 border rounded-md border-gray-400 checked:bg-primary-500 checked:border-primary-500 focus:outline-none;
-}
-.form-tick:checked {
-  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M5.707 7.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0-1.414-1.414L7 8.586 5.707 7.293z'/%3e%3c/svg%3e");
-  border-color: transparent;
-  background-size: 120% 120%;
-  background-position: 50%;
-  background-repeat: no-repeat;
 }
 </style>

--- a/src/components/LcForm/LcForm.stories.ts
+++ b/src/components/LcForm/LcForm.stories.ts
@@ -38,7 +38,7 @@ Base.args = {
       inputType: 'input',
       attr: {
         disabled: true,
-        wrapperClass: 'w-full lc-col mb-4',
+        wrapperClass: 'w-full mb-4',
         placeholder: 'Ecrit dedans :)',
         label: 'Prénom',
         name: 'firstname',
@@ -49,7 +49,7 @@ Base.args = {
       model: '',
       inputType: 'input',
       attr: {
-        wrapperClass: 'w-full lc-col mb-4',
+        wrapperClass: 'w-full mb-4',
         label: 'addresse',
         name: 'address',
         rules: 'required',
@@ -59,7 +59,7 @@ Base.args = {
       model: '',
       inputType: 'textarea',
       attr: {
-        inputClass: 'w-full lc-col mb-4',
+        wrapperClass: 'w-full mb-4',
         label: 'Votre demande',
         placeholder: 'Détailler votre demande',
         name: 'request',

--- a/src/components/LcInput/LcInput.vue
+++ b/src/components/LcInput/LcInput.vue
@@ -9,20 +9,18 @@
       </label>
     </slot>
 
-    <div class="w-full">
-      <input
-        :id="$attrs.id || name"
-        :ref="name"
-        :value="inputValue"
-        :class="computedClass"
-        :name="name"
-        :placeholder="placeholder"
-        v-bind="$attrs"
-        @input="onInput"
-        @change="handleChange"
-        @blur="onBlur"
-      >
-    </div>
+    <input
+      :id="$attrs.id || name"
+      :ref="name"
+      :value="inputValue"
+      :class="computedClass"
+      :name="name"
+      :placeholder="placeholder"
+      v-bind="$attrs"
+      @input="onInput"
+      @change="handleChange"
+      @blur="onBlur"
+    >
 
     <error-message :name="name" as="span" class="lc-input--error" />
   </div>
@@ -39,25 +37,25 @@ export default defineComponent({
   },
   inheritAttrs: false,
   props: {
-    noBorder: {
-      type: Boolean,
-      default: false,
-    },
     disabled: {
       type: Boolean,
       default: false,
-    },
-    wrapperClass: {
-      type: String,
-      default: 'w-full mb-4',
     },
     label: {
       type: String,
       default: '',
     },
+    modelValue: {
+      type: [String, Number],
+      default: '',
+    },
     name: {
       type: String,
       required: true,
+    },
+    noBorder: {
+      type: Boolean,
+      default: false,
     },
     placeholder: {
       type: String,
@@ -67,9 +65,9 @@ export default defineComponent({
       type: String,
       default: '',
     },
-    modelValue: {
-      type: [String, Number],
-      default: '',
+    wrapperClass: {
+      type: String,
+      default: 'w-full mb-4',
     },
   },
   emits: ['update:modelValue', 'blur'],
@@ -117,7 +115,7 @@ export default defineComponent({
 })
 </script>
 
-<style scoped>
+<style>
 .lc-input {
   height: 51px;
   transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;

--- a/src/components/LcMultiselect/LcMultiselect.vue
+++ b/src/components/LcMultiselect/LcMultiselect.vue
@@ -1,12 +1,12 @@
 <template>
   <div :class="wrapperClass">
-    <label v-if="labelText" class="block mb-1">
+    <label v-if="labelText" class="lc-form-label">
       {{ labelText }}
     </label>
 
     <multiselect
       v-model="inputValue"
-      :class="[{ 'lc-multiselect--hasError': isError }]"
+      :class="[{ 'lc-form--hasError': isError }]"
       :options="options"
       v-bind="{searchable: false, ...$attrs}"
       @change="handleChange"
@@ -17,7 +17,7 @@
     <error-message
       :name="name"
       as="span"
-      class="lc-multiselect--error"
+      class="lc-form--error"
     />
   </div>
 </template>
@@ -102,15 +102,5 @@ export default defineComponent({
   --ms-option-bg-selected: #e7d4b7;
   --ms-option-bg-selected-pointed: #e7d4b7;
   --ms-ring-color: #dbbc8f40;
-}
-</style>
-
-<style scoped>
-.lc-multiselect--error {
-  @apply text-sm text-error;
-}
-
-.lc-multiselect--hasError {
-  @apply border-error;
 }
 </style>

--- a/src/components/LcRadio/LcRadio.vue
+++ b/src/components/LcRadio/LcRadio.vue
@@ -14,7 +14,8 @@
       :disabled="disabled"
       :name="name"
       :value="value"
-      class="lc-radio"
+      class="lc-radio lc-form-tick"
+      data-testid="lc-radio"
       type="radio"
       v-bind="$attrs"
       @change="onChange"
@@ -68,7 +69,7 @@ export default defineComponent({
   },
 })
 </script>
-<style scoped>
+<style>
 .lc-radio-label {
   @apply inline-flex justify-start items-center mr-4 cursor-pointer;
 }
@@ -83,14 +84,6 @@ export default defineComponent({
 
 .lc-radio {
   @apply appearance-none cursor-pointer mr-2 border border-gray-400 rounded-full checked:bg-primary-500 checked:border-primary-500 w-6 h-6 md:w-4 md:h-4;
-}
-
-.lc-radio:checked {
-  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M5.707 7.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0-1.414-1.414L7 8.586 5.707 7.293z'/%3e%3c/svg%3e");
-  border-color: transparent;
-  background-size: 120% 120%;
-  background-position: 50%;
-  background-repeat: no-repeat;
 }
 
 .lc-radio:hover:not(:checked) {

--- a/src/components/LcRadio/LcRadioGroup.vue
+++ b/src/components/LcRadio/LcRadioGroup.vue
@@ -1,6 +1,10 @@
 <template>
   <div :class="wrapperClass">
-    <label v-if="label" class="lc-radiogroup-label">
+    <label
+      v-if="label"
+      class="lc-form-label"
+      data-testid="lc-radiogroup-label"
+    >
       {{ label }}
     </label>
     <div :class="['lc-radiogroup-layout', {'lc-radiogroup-layout--vertical': vertical }]">
@@ -14,7 +18,7 @@
         @update:modelValue="onChange"
       />
     </div>
-    <error-message :name="name" as="span" class="lc-radiogroup--error" />
+    <error-message :name="name" as="span" class="lc-form--error" />
   </div>
 </template>
 
@@ -83,20 +87,12 @@ export default defineComponent({
   },
 })
 </script>
-<style scoped>
-.lc-radiogroup-label {
-  @apply mb-2;
-}
-
+<style>
 .lc-radiogroup-layout {
   @apply flex;
 }
 
 .lc-radiogroup-layout--vertical {
   @apply flex-col;
-}
-
-.lc-radiogroup--error {
-  @apply text-sm text-error mt-1;
 }
 </style>

--- a/src/components/LcRadio/__tests__/LcRadioGroup.spec.ts
+++ b/src/components/LcRadio/__tests__/LcRadioGroup.spec.ts
@@ -28,26 +28,26 @@ describe('LcRadioGroup', () => {
 
   describe('Input behaviour', () => {
     it('should render good number of radio-buttons', () => {
-      const radiosButtons = wrapper.findAll('.lc-radio')
+      const radiosButtons = wrapper.findAll('[data-testid="lc-radio"]')
 
       expect(radiosButtons).toHaveLength(3)
     })
 
     it('should set good name attribute', () => {
-      const radiosButtons = wrapper.findAll('.lc-radio')
+      const radiosButtons = wrapper.findAll('[data-testid="lc-radio"]')
 
       expect(radiosButtons[1].attributes('value')).toEqual('ms')
     })
 
     it('should emit the event', () => {
-      const radioButton = wrapper.find('.lc-radio')
+      const radioButton = wrapper.find('[data-testid="lc-radio"]')
       radioButton.trigger('change')
 
       expect(wrapper.emitted()).toHaveProperty('update:modelValue')
     })
 
     it('should emit the right value', () => {
-      const radioButton = wrapper.find('.lc-radio')
+      const radioButton = wrapper.find('[data-testid="lc-radio"]')
       radioButton.trigger('change')
 
       const changeEvent = wrapper.emitted('update:modelValue')
@@ -60,7 +60,7 @@ describe('LcRadioGroup', () => {
     it('it should render the right label', async() => {
       await wrapper.setProps({ label: 'Your civility :' })
 
-      const label = wrapper.find('.lc-radiogroup-label')
+      const label = wrapper.find('[data-testid="lc-radiogroup-label"]')
       expect(label.text()).toEqual('Your civility :')
     })
 

--- a/src/components/LcTextarea/LcTextarea.vue
+++ b/src/components/LcTextarea/LcTextarea.vue
@@ -4,29 +4,27 @@
       <label
         v-if="label"
         :for="$attrs.id || name"
-        class="block mb-1"
+        class="lc-form-label"
       >
         {{ label }}
       </label>
     </slot>
-    <div class="w-full">
-      <textarea
-        :id="$attrs.id || name"
-        :ref="name"
-        :class="computedClass"
-        :name="name"
-        :placeholder="placeholder"
-        :value="inputValue"
-        v-bind="$attrs"
-        @blur="onBlur"
-        @change="handleChange"
-        @input="onInput"
-      />
-    </div>
+    <textarea
+      :id="$attrs.id || name"
+      :ref="name"
+      :class="computedClass"
+      :name="name"
+      :placeholder="placeholder"
+      :value="inputValue"
+      v-bind="$attrs"
+      @blur="onBlur"
+      @change="handleChange"
+      @input="onInput"
+    />
     <error-message
       :name="name"
       as="span"
-      class="lc-textarea--error"
+      class="lc-form--error"
     />
   </div>
 </template>
@@ -100,20 +98,14 @@ export default defineComponent({
   },
   computed: {
     computedClass(): any[] {
-      return ['lc-textarea', { 'lc-textarea--hasError': this.isError }]
+      return ['lc-textarea', { 'lc-form--hasError': this.isError }]
     },
   },
 })
 </script>
 
-<style scoped>
+<style>
 .lc-textarea {
   @apply block rounded-sm bg-clip-padding w-full border border-gray-400 text-gray-700 font-normal text-base leading-normal py-1.5 px-4 bg-white resize-none overflow-y-scroll focus:bg-white focus:border-primary-focus focus:shadow-focus focus:outline-none;
-}
-.lc-textarea--hasError {
-  @apply border-error;
-}
-.lc-textarea--error {
-  @apply text-sm text-error;
 }
 </style>

--- a/src/form.css
+++ b/src/form.css
@@ -1,0 +1,19 @@
+.lc-form-label {
+  @apply block mb-1;
+}
+
+.lc-form-tick:checked {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M5.707 7.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0-1.414-1.414L7 8.586 5.707 7.293z'/%3e%3c/svg%3e");
+  border-color: transparent;
+  background-size: 120% 120%;
+  background-position: 50%;
+  background-repeat: no-repeat;
+}
+
+.lc-form--error {
+  @apply text-sm text-error;
+}
+
+.lc-form--hasError {
+  @apply border-error;
+}

--- a/src/library.ts
+++ b/src/library.ts
@@ -1,3 +1,5 @@
+import './form.css'
+
 import LcBadge from './components/LcBadge'
 import LcButton from './components/LcButton'
 import LcCheckbox from './components/LcCheckbox'


### PR DESCRIPTION
- Ajout d'une feuille de style form.css pour centraliser les styles liés à plusieurs composants (comme les labels, les erreurs). 
- Modifier certain test unitaire pour ajouter des data-testid plutôt que directement la class.

Dites moi ce que vous en pensez ?