### PR TITLE
feat(LcButton/LcCount): [ch8200] fix color / margin icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lc-component-library",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "license": "MIT",
   "files": [
     "dist"

--- a/src/components/LcButton/LcButton.stories.ts
+++ b/src/components/LcButton/LcButton.stories.ts
@@ -21,6 +21,17 @@ const Template = (args: any) => ({
   template: '<lc-button v-bind="args">Hello world</lc-button>',
 })
 
+const TemplateTextIcon = (args: any) => ({
+  components: { LcButton, LcIcon },
+  setup() {
+    return { args }
+  },
+  template: `
+  <lc-button v-bind="args">
+    <lc-icon name="requests" /> Hello world
+  </lc-button>`,
+})
+
 const TemplateIcon = (args: any) => ({
   components: { LcButton, LcIcon },
   setup() {
@@ -37,6 +48,7 @@ Primary.args = {
   color: 'primary',
   variant: 'btn',
 }
+
 export const Secondary = Template.bind({}) as any
 Secondary.args = {
   color: 'secondary',
@@ -48,13 +60,22 @@ IconPrimary.args = {
   color: 'primary',
   variant: 'icon',
 }
+
 export const IconSecondary = TemplateIcon.bind({}) as any
 IconSecondary.args = {
   color: 'secondary',
   variant: 'icon',
 }
+
 export const IconRed = TemplateIcon.bind({}) as any
 IconRed.args = {
   color: 'red',
   variant: 'icon',
+}
+
+export const TextAndIcon = TemplateTextIcon.bind({}) as any
+TextAndIcon.args = {
+  color: 'primary',
+  variant: 'btn',
+  hasIcon: true,
 }

--- a/src/components/LcButton/LcButton.vue
+++ b/src/components/LcButton/LcButton.vue
@@ -260,7 +260,7 @@ export default defineComponent({
 .lc-btn.lc-btn--has-icon,
 .lc-link.lc-link--has-icon,
 .lc-outline.lc-outline--has-icon {
-  @apply flex items-center justify-center;
+  @apply flex items-center justify-center gap-x-2;
 }
 
 /* Block */

--- a/src/components/LcCount/LcCount.vue
+++ b/src/components/LcCount/LcCount.vue
@@ -28,6 +28,6 @@ export default defineComponent({
 
 <style>
 .lc-count {
-  @apply border border-gray-200 bg-gray-200 rounded-full w-8 h-8 flex text-xs items-center justify-center text-gray-400 mx-1;
+  @apply border border-gray-200 bg-gray-200 rounded-full w-8 h-8 flex text-xs items-center justify-center text-gray-600 mx-1;
 }
 </style>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -37,7 +37,7 @@ module.exports = {
         red: {
           100: '#E38687',
           200: '#DC6869',
-          300: '#EFCCC3',
+          300: '#B05354',
         },
         transparent: 'transparent',
         'primary-focus': '#dbbc8f40',


### PR DESCRIPTION
- Changement color LcCount
- Ajout d'un gap-x pour le bouton quand il y a une icon + texte (sachant que l'icon peut être avant ou apres le texte il aurait fallut géré 2 margin donc j'ai fait avec un gap)
- Ajout d'une story pour le LcButton

**Pas fait sur la lib**
Le bouton été déjà en `red-100`
La couleur de l'icon étant géré dans léonardo directement sur l'icon, je le fais sur léonardo j'ai augmenté de` red-200` à `red-300`


Tests
Vérifier sur storybook que les couleurs soit OK