### PR TITLE
fix(tabs, accordion): mobile design tabsnav+nopadding body props accordion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lc-component-library",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "MIT",
   "files": [
     "dist"

--- a/src/components/LcAccordion/LcAccordion.stories.ts
+++ b/src/components/LcAccordion/LcAccordion.stories.ts
@@ -69,6 +69,12 @@ Base.args = {
   modelValue: true,
 }
 
+export const HaveNoBodyPadding = Template.bind({}) as any
+HaveNoBodyPadding.args = {
+  ...Base.args,
+  hasBodyPadding: false,
+}
+
 export const HaveToogle = Template.bind({}) as any
 HaveToogle.args = {
   ...Base.args,

--- a/src/components/LcAccordion/LcAccordion.vue
+++ b/src/components/LcAccordion/LcAccordion.vue
@@ -51,7 +51,7 @@
         data-testid="lc-accordion-body"
         :style="containerStyle"
       >
-        <div ref="wrapper" class="lc-accordion-body-wrapper">
+        <div ref="wrapper" :class="['lc-accordion-body-wrapper', {'lc-accordion-body-wrapper--withpadding': hasBodyPadding}]">
           <slot name="body" />
         </div>
       </div>
@@ -59,7 +59,7 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { defineComponent } from 'vue'
 
 import LcButton from '../LcButton'
@@ -74,6 +74,10 @@ export default defineComponent({
     duration: {
       type: Number,
       default: 250,
+    },
+    hasBodyPadding: {
+      type: Boolean,
+      default: true,
     },
     haveToggle: {
       type: Boolean,
@@ -90,7 +94,7 @@ export default defineComponent({
   },
   emits: ['update:modelValue'],
   computed: {
-    containerStyle() {
+    containerStyle(): Record<string, string> {
       return {
         transitionDuration: `${this.duration}ms`,
       }
@@ -154,6 +158,9 @@ export default defineComponent({
    @apply overflow-hidden h-0 ease-in-out transition-height;
 }
 .lc-accordion-body-wrapper {
-  @apply px-9 py-5 w-full;
+  @apply w-full;
+}
+.lc-accordion-body-wrapper--withpadding {
+  @apply px-9 py-5;
 }
 </style>

--- a/src/components/LcAccordion/__tests__/LcAccordion.spec.ts
+++ b/src/components/LcAccordion/__tests__/LcAccordion.spec.ts
@@ -44,6 +44,18 @@ describe('LcAccordion', () => {
       const body = wrapper.find('[data-testid="lc-accordion-body"]')
       expect(body.isVisible()).toBe(true)
     })
+
+    it('should set bodypadding class on body-wrapper', () => {
+      const bodyWrapper = wrapper.find('[data-testid="lc-accordion-body"] > div')
+      expect(bodyWrapper.classes()).toContain('lc-accordion-body-wrapper--withpadding')
+    })
+
+    it('should not set bodypadding class on body-wrapper', async() => {
+      await wrapper.setProps({ hasBodyPadding: false })
+
+      const bodyWrapper = wrapper.find('[data-testid="lc-accordion-body"] > div')
+      expect(bodyWrapper.classes()).not.toContain('lc-accordion-body-wrapper--withpadding')
+    })
   })
 
   describe('Toggle button', () => {

--- a/src/components/LcTabs/LcTabs.vue
+++ b/src/components/LcTabs/LcTabs.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="lc-tabs-container">
+  <div :class="['lc-tabs-container', {'lc-tabs-container--sidecontent': isSideContent }]">
     <ul class="lc-tabs-navigation" role="tablist">
       <li
         v-for="(tab, i) of tabs"
@@ -34,9 +34,13 @@ export default defineComponent({
     },
   },
   emits: ['update:modelValue'],
-  setup(props, { emit }) {
+  setup(props, { emit, slots }) {
     const active = computed(() => props.modelValue)
     const tabs = ref<ComponentInternalInstance[]>([])
+
+    const isSideContent = computed(() => {
+      return Boolean(slots.sideContent) ?? null
+    })
 
     function selectTab(tab: number) {
       emit('update:modelValue', tab)
@@ -49,6 +53,7 @@ export default defineComponent({
 
     return {
       active,
+      isSideContent,
       selectTab,
       tabs,
     }
@@ -58,22 +63,24 @@ export default defineComponent({
 
 <style>
 .lc-tabs-container {
-  @apply flex items-center border-gray-400 pb-4;
+  @apply flex border-gray-400 pb-4;
 }
+
+.lc-tabs-container--sidecontent {
+  @apply flex-col-reverse;
+}
+
 @screen lg {
   .lc-tabs-container {
     @apply items-end border-b;
   }
+  .lc-tabs-container--sidecontent {
+    @apply flex-row;
+  }
 }
 
 .lc-tabs-navigation {
-  @apply h-full flex-1 flex flex-col gap-x-8;
-}
-
-@screen lg {
-  .lc-tabs-navigation {
-    @apply flex-row;
-  }
+  @apply h-full flex-1 flex gap-x-8;
 }
 
 .lc-tabs-link {
@@ -84,11 +91,9 @@ export default defineComponent({
   @apply text-active;
 }
 
-@screen lg {
-  .lc-tabs-link--active:after {
-    content: '';
-    @apply absolute h-0.5 left-0 -bottom-4 w-full bg-active;
-  }
+.lc-tabs-link--active:after {
+  content: '';
+  @apply absolute h-0.5 left-0 -bottom-4 w-full bg-active;
 }
 
 .lc-tabs-tabpanel {

--- a/src/components/LcTabs/LcTabs.vue
+++ b/src/components/LcTabs/LcTabs.vue
@@ -1,12 +1,18 @@
 <template>
-  <div :class="['lc-tabs-container', {'lc-tabs-container--sidecontent': isSideContent }]">
+  <div
+    :class="[
+      'lc-tabs-container',
+      { 'lc-tabs-container--sidecontent': isSideContent }
+    ]"
+    data-testid="lc-tabs-container"
+  >
     <ul class="lc-tabs-navigation" role="tablist">
       <li
         v-for="(tab, i) of tabs"
         :key="i"
         :aria-selected="active === i"
         :aria-controls="`panel-${i}`"
-        :class="['lc-tabs-link', {'lc-tabs-link--active': active === i}]"
+        :class="['lc-tabs-link', { 'lc-tabs-link--active': active === i }]"
         data-testid="lc-tabs-link"
         role="tab"
         tabindex="0"
@@ -39,7 +45,7 @@ export default defineComponent({
     const tabs = ref<ComponentInternalInstance[]>([])
 
     const isSideContent = computed(() => {
-      return Boolean(slots.sideContent) ?? null
+      return Boolean(slots.sideContent)
     })
 
     function selectTab(tab: number) {

--- a/src/components/LcTabs/Tabs.stories.ts
+++ b/src/components/LcTabs/Tabs.stories.ts
@@ -35,7 +35,7 @@ const TemplateSlotSideContent = (args: any) => ({
   template: `
   <lc-tabs v-model="currentTab">
     <template #sideContent>
-      <lc-button>button side</lc-button>
+      <lc-button class="mb-6">button side</lc-button>
     </template>
     <lc-tab title="Tab A">Content A</lc-tab>
     <lc-tab title="Tab B">Content B</lc-tab>

--- a/src/components/LcTabs/__tests__/LcTabs.spec.ts
+++ b/src/components/LcTabs/__tests__/LcTabs.spec.ts
@@ -53,4 +53,9 @@ describe('LcTabs.vue', () => {
     const sideContent = wrapper.find('[data-testid="lc-tabs-sidecontent"]')
     expect(sideContent).toBeTruthy()
   })
+
+  it('should set sidecontent class on container', async() => {
+    const container = wrapper.find('[data-testid="lc-tabs-container"]')
+    expect(container.classes()).toContain('lc-tabs-container--sidecontent')
+  })
 })


### PR DESCRIPTION
Ajouts et fix sur les composants : `lc-tabs` & `lc-accordion`

**Lc-Tabs :**

- Refacto de la disposition de la nav en mobile (en ligne avec marker comme sur desktop)

**Lc-Accordion :**

- Ajout d'une props `hasBodyPadding` qui est par défault à `true` (px-9 py-5). 
Si on souhaite avoir un padding custom dans le body de l'accordion => `hasBodyPadding` à `false`, puis ajout (ou pas) des paddings custom.
