### PR TITLE
chore(LcAccordion): [ch8154] fix overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lc-component-library",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "license": "MIT",
   "files": [
     "dist"

--- a/src/components/LcAccordion/LcAccordion.stories.ts
+++ b/src/components/LcAccordion/LcAccordion.stories.ts
@@ -69,12 +69,6 @@ Base.args = {
   modelValue: true,
 }
 
-export const HaveNoBodyPadding = Template.bind({}) as any
-HaveNoBodyPadding.args = {
-  ...Base.args,
-  hasBodyPadding: false,
-}
-
 export const HaveToogle = Template.bind({}) as any
 HaveToogle.args = {
   ...Base.args,
@@ -109,4 +103,10 @@ export const HaveButtonLeftAndToggle = TemplateSlotActionsBefore.bind({}) as any
 HaveButtonLeftAndToggle.args = {
   ...HaveButtonLeft.args,
   haveToggle: true,
+}
+
+export const HaveNoBodyPadding = Template.bind({}) as any
+HaveNoBodyPadding.args = {
+  ...Base.args,
+  hasBodyPadding: false,
 }

--- a/src/components/LcAccordion/LcAccordion.vue
+++ b/src/components/LcAccordion/LcAccordion.vue
@@ -65,6 +65,8 @@ import { defineComponent } from 'vue'
 import LcButton from '../LcButton'
 import LcIcon from '../LcIcon'
 
+type Height = number | 'auto'
+
 export default defineComponent({
   components: {
     LcButton,
@@ -102,28 +104,31 @@ export default defineComponent({
   },
   mounted() {
     if (this.modelValue) {
-      const el = this.$refs['lc-accordion-body']
+      const el = this.$refs['lc-accordion-body'] as HTMLElement
       this.setContainerHeight('auto', el)
     }
   },
   methods: {
     getContentHeight() {
-      const wrapper = this.$refs.wrapper
+      const wrapper = this.$refs.wrapper as HTMLElement
       return wrapper?.getBoundingClientRect().height || 0
     },
-    onEnter(el) {
+    onEnter(el: HTMLElement) {
       this.setContainerHeight(this.getContentHeight(), el)
+      el.style.overflow = 'hidden'
     },
-    onAfterEnter(el) {
+    onAfterEnter(el: HTMLElement) {
       this.setContainerHeight('auto', el)
+      el.style.overflow = 'visible'
     },
-    onBeforeLeave(el) {
+    onBeforeLeave(el: HTMLElement) {
       this.setContainerHeight(this.getContentHeight(), el)
+      el.style.overflow = 'hidden'
     },
-    onLeave(el) {
+    onLeave(el: HTMLElement) {
       this.setContainerHeight(0, el)
     },
-    setContainerHeight(height, el) {
+    setContainerHeight(height: Height, el: HTMLElement) {
       el.style.height = typeof height === 'number' ? `${height}px` : height
     },
     toggle() {
@@ -155,7 +160,7 @@ export default defineComponent({
 }
 
 .lc-accordion-body {
-   @apply overflow-hidden h-0 ease-in-out transition-height;
+   @apply h-0 ease-in-out transition-height;
 }
 .lc-accordion-body-wrapper {
   @apply w-full;


### PR DESCRIPTION
- Gestion de l'overflow dans le `js` pour laissé le overflow-visible quand l'accordion est ouvert
Pour résoudre se bug sur léo (si le dropdown est plus grand que l'accordion les filtres sont coupés)

<img width="1023" alt="Capture d’écran 2021-10-26 à 15 03 58" src="https://user-images.githubusercontent.com/7684148/138825520-2e224244-fb2a-4c87-8041-2e597d4b570d.png">

- Typage des elements HTML


On peut pas vraiment le tester tant que ce n'est pas sur leo